### PR TITLE
fix meiki color shift

### DIFF
--- a/owocr/ocr.py
+++ b/owocr/ocr.py
@@ -2135,5 +2135,4 @@ class OCRSpace:
 
     def _preprocess(self, img):
         return limit_image_size(img, self.max_byte_size)
-
-
+        


### PR DESCRIPTION
Resolves an issue with color shift messing with Meiki OCR results. Am able to reproduce very reliably on this image and a few others. Worked with @rtr46 on finding this and the proposed fix.

Raw
<img width="2560" height="1439" alt="latest_overlay_screenshot" src="https://github.com/user-attachments/assets/d78a29ee-d424-42cf-a623-52a6d249ecf0" />

---

Color Shifted (code being changed)

<img width="2560" height="1439" alt="meikiocr_input" src="https://github.com/user-attachments/assets/9a19647e-fd00-4ccd-bf66-0c2be0811702" />

---

<img width="1024" height="826" alt="image" src="https://github.com/user-attachments/assets/2a8840cf-6aa5-457e-93d6-22f1bd4b116b" />