### PR TITLE
Add scale_x and scale_y fields to image_properties

### DIFF
--- a/owocr/ocr.py
+++ b/owocr/ocr.py
@@ -155,6 +155,8 @@ class ImageProperties:
     window_handle: Optional[int] = None # Optional: handle of the scanned window
     window_x: Optional[int] = None # Optional: X position of the scanned area relative to the window
     window_y: Optional[int] = None # Optional: Y position of the scanned area relative to the window
+    scale_x: Optional[float] = None # Optional: horizontal DPI scaling factor, only set for DPI-unaware windows
+    scale_y: Optional[float] = None # Optional: vertical DPI scaling factor, only set for DPI-unaware windows
 
 @dataclass
 class EngineCapabilities:


### PR DESCRIPTION
It turns out that when a game window is DPI-unaware and the Window scaling is not set exactly to 100%, none of the `bounding_box` values correspond to the scaled window as seen by the user. This is likely because `PrintWindow` captures the image in its pre-scaled form (which is probably desirable for both OCR quality and performance).

As far as I can tell, there are essentially two ways to address this:
1. Normalize the bounding boxes inside OwOCR by multiplying the relevant values by the corresponding scaling factors, i.e., `center_x * scale_x`, `center_y * scale_y`, `width * scale_x`, and` height * scale_y`.
2. Expose the `scale_x` and `scale_y` factors so that clients can normalize the results themselves.

The first approach is more elegant and less confusing from a client perspective, since `image_properties` _are_ already reported in physical pixels even when the window is DPI-unaware. Which makes including `scale_x` and `scale_y` as a part of `image_properties` even more confusing.

However, I was not able to implement the first approach elegantly while keeping code changes to a minimum, so for now I went with the second approach. If you are willing to implement the first approach, please feel free to close this PR in favor of that as that seems more desirable.