### PR TITLE
Fix "Darwin" case on clipboard platform check

### DIFF
--- a/owocr/run.py
+++ b/owocr/run.py
@@ -2434,7 +2434,7 @@ class OutputResult:
                 win32clipboard.CloseClipboard()
             except pywintypes.error:
                 pass
-        elif sys.platform == 'Darwin':
+        elif sys.platform == 'darwin':
             with objc.autorelease_pool():
                 pb = NSPasteboard.generalPasteboard()
                 pb.clearContents()


### PR DESCRIPTION
On macOS, sys.platform is "darwin" and not "Darwin", so owocr will fail when using a clipboard output.