### PR TITLE
properly substitute input that can contain loguru style tags

### DIFF
--- a/owocr/run.py
+++ b/owocr/run.py
@@ -2469,7 +2469,10 @@ class OutputResult:
                 end_time = time.monotonic()
 
                 if not res2:
-                    logger.opt(colors=True).warning(f'<{self.engine_color}>{engine_instance_2.readable_name}</> reported an error after {end_time - start_time:0.03f}s: {result_data_2}')
+                    logger.opt(colors=True).warning(
+                        f'<{self.engine_color}>{{name}}</> reported an error after {{duration:0.03f}}s: {{result}}',
+                        name=engine_instance_2.readable_name, duration=end_time - start_time, result=result_data_2,
+                    )
                 else:
                     changed_lines_count, recovered_lines_count, changed_regions_image = self.filtering.find_changed_lines(img_or_path, result_data_2)
 
@@ -2505,7 +2508,10 @@ class OutputResult:
         if not res:
             if auto_pause_handler and auto_pause:
                 auto_pause_handler.stop_timer()
-            logger.opt(colors=True).warning(f'<{self.engine_color}>{engine_name}</> reported an error after {processing_time:0.03f}s: {result_data}')
+            logger.opt(colors=True).warning(
+                f'<{self.engine_color}>{{name}}</> reported an error after {{time:0.03f}}s: {{result}}',
+                name=engine_name, time=processing_time, result=result_data
+            )
             return
 
         if isinstance(result_data, OcrResult):
@@ -2551,7 +2557,10 @@ class OutputResult:
             else:
                 log_message = ': ' + (output_text if len(output_text) <= self.verbosity else output_text[:self.verbosity] + '[...]')
 
-            logger.opt(colors=True).info(f'Text recognized in {processing_time:0.03f}s using <{self.engine_color}>{engine_name}</>{log_message}')
+            logger.opt(colors=True).info(
+                f'Text recognized in {{processing_time:0.03f}}s using <{self.engine_color}>{{engine_name}}</>{{log_message}}',
+                processing_time=processing_time, engine_name=engine_name, log_message=log_message,
+            )
 
         if notify and self.notifications:
             notifier.send(title='owocr', message='Text recognized: ' + output_text, urgency=get_notification_urgency())
@@ -2883,7 +2892,10 @@ def run():
     user_input_thread.start()
 
     if not terminated.is_set():
-        logger.opt(colors=True).info(f"Reading from {' and '.join(read_from_readable)}, writing to {write_to_readable} using <{engine_color}>{engine_instances[engine_index].readable_name}</>{' (paused)' if paused.is_set() else ''}")
+        logger.opt(colors=True).info(
+            f"Reading from {{sources}}, writing to {{write_to_readable}} using <{engine_color}>{{engine}}</>{{pause}}",
+            sources=' and '.join(read_from_readable), write_to_readable=write_to_readable, engine=engine_instances[engine_index].readable_name, pause=' (paused)' if paused.is_set() else ''
+        )
 
     while not terminated.is_set():
         img = None


### PR DESCRIPTION
When using `logger.opt(colors=True)`, using f-strings to construct a log message can lead to `<` and `>` being treated as special characters, leading to errors like the following when OCRing text that contains those characters:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/user/tmp/owocr-git/owocr/__main__.py", line 8, in <module>
    main()
  File "/Users/user/tmp/owocr-git/owocr/__main__.py", line 4, in main
    run()
  File "/Users/user/tmp/owocr-git/owocr/run.py", line 2895, in run
    logger.opt(colors=True).info(f"Reading from {' and '.join(read_from_readable)}, writing to {write_to_readable} using <{engine_color}>{engine_instances[engine_index].readable_name}</>{' (paused)' if paused.is_set() else ''}")
  File "/Users/user/tmp/owocr/.venv/lib/python3.11/site-packages/loguru/_logger.py", line 2078, in info
    __self._log("INFO", False, __self._options, __message, args, kwargs)
  File "/Users/user/tmp/owocr/.venv/lib/python3.11/site-packages/loguru/_logger.py", line 2051, in _log
    colored_message = Colorizer.prepare_simple_message(str(message))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/tmp/owocr/.venv/lib/python3.11/site-packages/loguru/_colorizer.py", line 378, in prepare_simple_message
    parser.feed(string)
  File "/Users/user/tmp/owocr/.venv/lib/python3.11/site-packages/loguru/_colorizer.py", line 260, in feed
    raise ValueError(
ValueError: Tag "<>" does not correspond to any known color directive, make sure you did not misspelled it (or prepend '\' to escape it)```

This PR properly escapes them where necessary. Note that I have only tested the last two log statements, because I couldn't think of an easy way to inject errors into the OCR engine.