### PR TITLE
Enforce Minimum size for Bing just like OneOCR

### DIFF
--- a/owocr/ocr.py
+++ b/owocr/ocr.py
@@ -1109,9 +1109,16 @@ class Bing:
         return x
 
     def _preprocess(self, img):
+        min_pixel_size = 50
         max_pixel_size = 4000
         max_byte_size = 767772
         res = None
+
+        if any(x < min_pixel_size for x in img.size):
+            resize_factor = max(min_pixel_size / img.width, min_pixel_size / img.height)
+            new_w = int(img.width * resize_factor)
+            new_h = int(img.height * resize_factor)
+            img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
 
         if any(x > max_pixel_size for x in img.size):
             resize_factor = min(max_pixel_size / img.width, max_pixel_size / img.height)


### PR DESCRIPTION
Recently updated GSM with your fix for the bot detection for Bing OCR.

While testing in GSM, noticed that Bing has the same exact issue as OneOCR when it comes to minimum size requirements. Most people won't run into this, but good to get it patched up before somebody else does. This is just the same fix as the one in OneOCR [here](https://github.com/AuroraWright/owocr/blob/4a7ef5d51a1722211e82f3d20a37bc7a67917b26/owocr/ocr.py#L1609).

そしていつもありがとうございます 👍 